### PR TITLE
Create a CanJS 4.0 version of can-observe

### DIFF
--- a/can-observe.js
+++ b/can-observe.js
@@ -146,11 +146,9 @@ Object.keys(mutateMethods).forEach(function(prop) {
 		var patches = mutateMethods[prop](this, Array.from(arguments), old);
 
 		queues.batch.start();
-		// dispatch all the associated change events
-		dispatch.call(this, patchesSymbol, [patches]);
-		// dispatch length
+		// dispatch all the associated change events and length
 		dispatch.call(this, "length", [this.length, old.length]);
-		dispatch.call(this, patchesSymbol, [[{property: "length", type: "set", value: this.length}]]);
+		dispatch.call(this, patchesSymbol, [patches.concat([{property: "length", type: "set", value: this.length}])]);
 		queues.batch.stop();
 		this[observableSymbol].inArrayMethod = false;
 		return ret;

--- a/can-observe.js
+++ b/can-observe.js
@@ -43,9 +43,9 @@ function shouldAddObservation(key, value, target) {
 // Proxy when all of the following conditions are true:
 //  - value is an object (it exists, so is not null, and has type "object")
 //  - key is not a symbol (symbolic properties are assumed not to be desired as observables)
-//  - for the read case, there is at least one listener for the property on the parent object
+//  - for the write case, there is at least one listener for the property on the parent object
 //  	(represented by the onlyIfHandlers flag)
-//  - for the write case, the previous stipulation does not apply.
+//  - for the read case, the previous stipulation does not apply; reads always return observed objects.
 function shouldObserveValue(key, value, target, onlyIfHandlers) {
 	return value && typeof value === "object" &&
 		!canReflect.isSymbolLike(key) &&
@@ -228,7 +228,7 @@ var observe = function(obj){
 				value = target[key];
 			}
 			// If the value for this key is an object and not already observable, make a proxy for it
-			if (shouldObserveValue(key, value, target, true)) {
+			if (shouldObserveValue(key, value, target)) {
 				value = target[key] = observe(value);
 			}
 			// Intercept calls to Array mutation methods.
@@ -246,7 +246,7 @@ var observe = function(obj){
 			var integerIndex = isIntegerIndex(key);
 			var descriptor = Object.getOwnPropertyDescriptor(target, key);
 			// make a proxy for any non-observable objects being passed in as values
-			if (shouldObserveValue(key, value, target)) {
+			if (shouldObserveValue(key, value, target, true)) {
 				value = observe(value);
 			} else if (value && value[observableSymbol]){
 				value = value[observableSymbol].proxy;

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "preversion": "npm test && npm run build",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",
-    "postversion": "git push --tags && git checkout master && git branch -D release && git push",
+    "postversion": "git push --tags && git checkout major && git branch -D release && git push",
     "testee": "testee test.html --browsers firefox",
     "test": "npm run detect-cycle && npm run jshint && npm run testee",
     "jshint": "jshint *.js --config",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "release:pre": "npm version prerelease && npm publish",
+    "release:pre": "npm version prerelease && npm publish --tag pre",
     "build": "node build.js",
     "detect-cycle": "detect-cyclic-packages --ignore done-serve"
   },

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "can-cid": "^1.0.1",
     "can-event": "^3.7.5",
     "can-namespace": "^1.0.0",
-    "can-observation": "^3.0.7",
+    "can-observation-recorder": "^0.1.0",
+    "can-queues": "^0.2.5",
     "can-reflect": "^1.4.2",
     "can-symbol": "^1.2.0"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",
-    "can-compute": "^3.0.5",
-    "can-stache": "^3.0.19",
+    "can-observation": "^4.0.0-pre.7",
     "can-util": "^3.2.2",
     "jshint": "^2.9.1",
     "steal": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/canjs/can-observe",
   "dependencies": {
     "can-cid": "^1.0.1",
+    "can-key-tree": "0.0.3",
     "can-namespace": "^1.0.0",
     "can-observation-recorder": "^0.1.0",
     "can-queues": "^0.2.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/canjs/can-observe",
   "dependencies": {
     "can-cid": "^1.0.1",
-    "can-event": "^3.7.5",
     "can-namespace": "^1.0.0",
     "can-observation-recorder": "^0.1.0",
     "can-queues": "^0.2.5",

--- a/test.js
+++ b/test.js
@@ -397,11 +397,13 @@ QUnit.test("array events are automatically triggered (push)", function() {
 	var newThing = 3;
 
 	list[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property) { return; } // ignore length property patches
-		QUnit.equal(patches.length, 1, "One patches generated");
-		QUnit.equal(patches[0].deleteCount, 0, "nothing removed");
-		QUnit.equal(patches[0].index, list.length - 1, "new thing added to end");
-		QUnit.deepEqual(patches[0].insert, [newThing], "new thing added to end");
+		QUnit.ok(patches.length > 1, "Patches generated");
+		patches.forEach(function(patch) {
+			if(patch.property) { return; } // ignore length property patches
+			QUnit.equal(patch.deleteCount, 0, "nothing removed");
+			QUnit.equal(patch.index, list.length - 1, "new thing added to end");
+			QUnit.deepEqual(patch.insert, [newThing], "new thing added to end");
+		});
 	});
 
 	list.push(newThing);
@@ -412,10 +414,12 @@ QUnit.test("array events are automatically triggered (pop)", function() {
 	var list = observe([1, 2, 3]);
 
 	list[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property) { return; } // ignore length property patches
-		QUnit.equal(patches.length, 1, "One patches generated");
-		QUnit.equal(patches[0].deleteCount, 1, "old thing removed");
-		QUnit.equal(patches[0].index, list.length, "old thing removed from end");
+		QUnit.ok(patches.length > 1, "Patches generated");
+		patches.forEach(function(patch) {
+			if(patch.property) { return; } // ignore length property patches
+			QUnit.equal(patch.deleteCount, 1, "old thing removed");
+			QUnit.equal(patch.index, list.length, "old thing removed from end");
+		});
 	});
 
 	list.pop();
@@ -427,11 +431,13 @@ QUnit.test("array events are automatically triggered (unshift)", function() {
 	var newThing = 3;
 
 	list[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property) { return; } // ignore length property patches
-		QUnit.equal(patches.length, 1, "One patches generated");
-		QUnit.equal(patches[0].deleteCount, 0, "nothing removed");
-		QUnit.equal(patches[0].index, 0, "new thing added to beginning");
-		QUnit.deepEqual(patches[0].insert, [newThing], "new thing added to beginning");
+		QUnit.ok(patches.length > 1, "Patches generated");
+		patches.forEach(function(patch) {
+			if(patch.property) { return; } // ignore length property patches
+			QUnit.equal(patch.deleteCount, 0, "nothing removed");
+			QUnit.equal(patch.index, 0, "new thing added to beginning");
+			QUnit.deepEqual(patch.insert, [newThing], "new thing added to beginning");
+		});
 	});
 
 	list.unshift(newThing);
@@ -442,10 +448,12 @@ QUnit.test("array events are automatically triggered (shift)", function() {
 	var list = observe([1, 2, 3]);
 
 	list[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property) { return; } // ignore length property patches
-		QUnit.equal(patches.length, 1, "One patches generated");
-		QUnit.equal(patches[0].deleteCount, 1, "old thing removed");
-		QUnit.equal(patches[0].index, 0, "old thing removed from beginning");
+		QUnit.ok(patches.length > 1, "Patches generated");
+		patches.forEach(function(patch) {
+			if(patch.property) { return; } // ignore length property patches
+			QUnit.equal(patch.deleteCount, 1, "old thing removed");
+			QUnit.equal(patch.index, 0, "old thing removed from beginning");
+		});
 	});
 
 	list.shift();
@@ -457,11 +465,13 @@ QUnit.test("array events are automatically triggered (splice)", function() {
 	var newThing = 4;
 
 	list[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property) { return; } // ignore length property patches
-		QUnit.equal(patches.length, 1, "One patches generated");
-		QUnit.equal(patches[0].deleteCount, 1, "nothing removed");
-		QUnit.equal(patches[0].index, 1, "new thing added to beginning");
-		QUnit.deepEqual(patches[0].insert, [newThing], "new thing added to beginning");
+		QUnit.ok(patches.length > 1, "Patches generated");
+		patches.forEach(function(patch) {
+			if(patch.property) { return; } // ignore length property patches
+			QUnit.equal(patch.deleteCount, 1, "nothing removed");
+			QUnit.equal(patch.index, 1, "new thing added to beginning");
+			QUnit.deepEqual(patch.insert, [newThing], "new thing added to beginning");
+		});
 	});
 
 	list.splice(1, 1, newThing);
@@ -472,8 +482,7 @@ QUnit.test("array events are automatically triggered (sort)", function() {
 	var list = observe(["a", "c", "b"]);
 
 	list[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property) { return; } // ignore length property patches
-		QUnit.deepEqual(patches, [
+		QUnit.deepEqual(patches.filter(function(p) { return !p.property; }), [
 			{"index":1,"deleteCount":0,"insert":["b"]},
 			{"index":3,"deleteCount":1,"insert":[]}
 		], "patches correct");
@@ -489,8 +498,7 @@ QUnit.test("array events are automatically triggered (reverse)", function() {
 	var expectedList = list.slice(0).reverse();
 
 	list[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property) { return; } // ignore length property patches
-		QUnit.deepEqual(patches, [
+		QUnit.deepEqual(patches.filter(function(p) { return !p.property; }), [
 			{"index":0,"deleteCount":3,"insert":expectedList}
 		], "patches replaces whole list");
 	});

--- a/test.js
+++ b/test.js
@@ -559,26 +559,30 @@ QUnit.test("patches events for set/deleted indexed properties on arrays", functi
 	var setArrayObject = observe([]);
 	var deleteArrayObject = observe(["a", "b"]);
 	setArrayObject[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property === "length") {
-			QUnit.equal(patches[0].type, "set");
-			QUnit.equal(patches[0].value, 1);			
-		} else {
-			QUnit.equal(patches[0].property, "0");
-			QUnit.equal(patches[0].type, "add");
-			QUnit.equal(patches[0].value, "a");
-		}
+		patches.forEach(function(patch) {
+			if(patch.property === "length") {
+				QUnit.equal(patch.type, "set");
+				QUnit.equal(patch.value, 1);			
+			} else {
+				QUnit.equal(patch.property, "0");
+				QUnit.equal(patch.type, "add");
+				QUnit.equal(patch.value, "a");
+			}
+		});
 	});
 	setArrayObject[0] = "a";
 
 	deleteArrayObject[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property === "length") {
-			QUnit.equal(patches[0].type, "set");
-			QUnit.equal(patches[0].value, 1);			
-		} else {
-			QUnit.equal(patches[0].property, "1");
-			QUnit.equal(patches[0].type, "remove");
-			QUnit.ok(!patches[0].value);
-		}
+		patches.forEach(function(patch) {
+			if(patch.property === "length") {
+				QUnit.equal(patch.type, "set");
+				QUnit.equal(patch.value, 1);
+			} else {
+				QUnit.equal(patch.property, "1");
+				QUnit.equal(patch.type, "remove");
+				QUnit.ok(!patch.value);
+			}
+		});
 	});
 	deleteArrayObject.length = 1; // deleting object at index 1 is implicit in setting length
 });
@@ -613,12 +617,14 @@ QUnit.test("changing an item at an array index dispatches a splice patch", funct
 	var a = observe([1, 2]);
 
 	a[canSymbol.for("can.onPatches")](function(patches) {
-		if(patches[0].property) {
-			return;
-		}
-		QUnit.equal(patches[0].index, 0);
-		QUnit.equal(patches[0].deleteCount, 1);
-		QUnit.deepEqual(patches[0].insert, [2]);
+		patches.forEach(function(patch) {
+			if(patch.property) {
+				return;
+			}
+			QUnit.equal(patch.index, 0);
+			QUnit.equal(patch.deleteCount, 1);
+			QUnit.deepEqual(patch.insert, [2]);
+		});
 	});
 
 	a[0] = 2;

--- a/test.js
+++ b/test.js
@@ -118,8 +118,6 @@ QUnit.test("Should convert nested objects to observables in a lazy way (get case
 
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted before read");
 	QUnit.equal(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol), -1, "nested is not observed");
-	QUnit.equal(canReflect.isObservableLike(obs.nested), false, "nested is not converted to a proxy before being observed");
-	canReflect.onKeyValue(obs, "nested", function() {});
 	QUnit.equal(canReflect.isObservableLike(obs.nested), true, "nested is converted to a proxy and the proxy returned");
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted after read");
 	QUnit.ok(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol) > -1, "nested is now observed");
@@ -132,8 +130,6 @@ QUnit.test("Should convert nested arrays to observables in a lazy way (get case)
 
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted before read");
 	QUnit.equal(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol), -1, "nested is not observed");
-	QUnit.equal(canReflect.isObservableLike(obs.nested), false, "nested is not converted to a proxy before being observed");
-	canReflect.onKeyValue(obs, "nested", function() {});
 	QUnit.equal(canReflect.isObservableLike(obs.nested), true, "nested is converted to a proxy and the proxy returned");
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted after read");
 	QUnit.ok(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol) > -1, "nested is now observed");
@@ -181,7 +177,6 @@ QUnit.test("Nested objects should be observables #21", function() {
 	var obj = {nested: {}, primitive: 2};
 	var obs = observe(obj);
 	obs.nested.prop = 1;
-	canReflect.onKeyValue(obs, "nested", function() {});
 	canReflect.onKeyValue(obs.nested, "prop", function(newVal) {
 		assert.ok(newVal === "abc", "change is triggered on a nested property");
 	});
@@ -248,7 +243,6 @@ QUnit.test("Should remove event handlers #21", function() {
 		result += '4';
 	};
 
-	canReflect.onKeyValue(obs, "nested");
 	canReflect.onKeyValue(obs.nested, "prop", handler1);
 	canReflect.onKeyValue(obs.nested, "prop", handler2);
 	canReflect.onKeyValue(obs.nested, "prop", handler3);

--- a/test.js
+++ b/test.js
@@ -118,6 +118,8 @@ QUnit.test("Should convert nested objects to observables in a lazy way (get case
 
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted before read");
 	QUnit.equal(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol), -1, "nested is not observed");
+	QUnit.equal(canReflect.isObservableLike(obs.nested), false, "nested is not converted to a proxy before being observed");
+	canReflect.onKeyValue(obs, "nested", function() {});
 	QUnit.equal(canReflect.isObservableLike(obs.nested), true, "nested is converted to a proxy and the proxy returned");
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted after read");
 	QUnit.ok(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol) > -1, "nested is now observed");
@@ -130,6 +132,8 @@ QUnit.test("Should convert nested arrays to observables in a lazy way (get case)
 
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted before read");
 	QUnit.equal(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol), -1, "nested is not observed");
+	QUnit.equal(canReflect.isObservableLike(obs.nested), false, "nested is not converted to a proxy before being observed");
+	canReflect.onKeyValue(obs, "nested", function() {});
 	QUnit.equal(canReflect.isObservableLike(obs.nested), true, "nested is converted to a proxy and the proxy returned");
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted after read");
 	QUnit.ok(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol) > -1, "nested is now observed");
@@ -142,7 +146,7 @@ QUnit.test("Should convert nested objects to observables (set case) #21", functi
 
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted before set");
 	QUnit.equal(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol), -1, "nested is not observed");
-	obj.nested = nested;
+	obs.nested = nested;
 	QUnit.equal(canReflect.isObservableLike(obs.nested), true, "nested is converted to a proxy and the proxy returned");
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted after set");
 	QUnit.ok(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol) > -1, "nested is now observed");
@@ -155,7 +159,7 @@ QUnit.test("Should convert nested arrays to observables (set case) #21", functio
 
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted before set");
 	QUnit.equal(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol), -1, "nested is not observed");
-	obj.nested = nested;
+	obs.nested = nested;
 	QUnit.equal(canReflect.isObservableLike(obs.nested), true, "nested is converted to a proxy and the proxy returned");
 	QUnit.ok(!canReflect.isObservableLike(nested), "nested is not converted after set");
 	QUnit.ok(Object.getOwnPropertySymbols(nested).indexOf(observableSymbol) > -1, "nested is now observed");
@@ -177,6 +181,7 @@ QUnit.test("Nested objects should be observables #21", function() {
 	var obj = {nested: {}, primitive: 2};
 	var obs = observe(obj);
 	obs.nested.prop = 1;
+	canReflect.onKeyValue(obs, "nested", function() {});
 	canReflect.onKeyValue(obs.nested, "prop", function(newVal) {
 		assert.ok(newVal === "abc", "change is triggered on a nested property");
 	});
@@ -243,6 +248,7 @@ QUnit.test("Should remove event handlers #21", function() {
 		result += '4';
 	};
 
+	canReflect.onKeyValue(obs, "nested");
 	canReflect.onKeyValue(obs.nested, "prop", handler1);
 	canReflect.onKeyValue(obs.nested, "prop", handler2);
 	canReflect.onKeyValue(obs.nested, "prop", handler3);


### PR DESCRIPTION
- Use patches instead of array events
- Use a WeakMap to store interceptors
- Use can-key-tree to manage handlers
- Use ObservationRecorder.add instead of Observation.add
- Dispatch all handler calls through can-queues