### PR TITLE
Implement getKeyDependencies for computed getters

### DIFF
--- a/array/array-test.js
+++ b/array/array-test.js
@@ -1,7 +1,8 @@
-var ObserveArray = require("./array");
-var ObserveObject = require("../object/object");
 var QUnit = require("steal-qunit");
-var metaSymbol = require("can-symbol").for("can.meta");
+var ObserveArray = require("./array");
+var canReflect = require("can-reflect");
+var ObserveObject = require("../object/object");
+
 QUnit.module("can-observe/array");
 
 var classSupport = (function() {
@@ -93,7 +94,7 @@ QUnit.test("getters work", function(){
 			actions.push("filter");
 			return this.filter(function(person){
 				return person.age > 21;
-			})
+			});
 		}
 	});
 
@@ -114,4 +115,28 @@ QUnit.test("getters work", function(){
 		"over21Callback 1"
 	],"behavior is right");
 
+});
+
+QUnit.test("getters getKeyDependencies", function(assert) {
+	var People = ObserveArray.extend("People", {}, {
+		get over21() {
+			return this.filter(function(person) {
+				return person.age > 21;
+			});
+		}
+	});
+
+	var people = new People([
+		{id: 1, age: 22},
+		{id: 2, age: 21},
+		{id: 3, age: 23}
+	]);
+
+	people.on("over21", function over21Callback() {});
+	assert.equal(people.over21.length, 2, "got the right number");
+
+	assert.ok(
+		canReflect.getKeyDependencies(people, "over21").valueDependencies,
+		"should return internal observation"
+	);
 });

--- a/object/object-test.js
+++ b/object/object-test.js
@@ -1,8 +1,9 @@
 var ObserveObject = require("./object");
 var QUnit = require("steal-qunit");
 var ObservationRecorder = require("can-observation-recorder");
-QUnit.module("can-observe/object");
+var canReflect = require("can-reflect");
 
+QUnit.module("can-observe/object");
 
 var classSupport = (function() {
 	try {
@@ -42,6 +43,23 @@ if(classSupport) {
 
 
     });
+
+	QUnit.test("computed getters getKeyDependencies", function(assert) {
+		class Person extends ObserveObject {
+			get fullName() {
+				return this.first + " " + this.last;
+			}
+		}
+
+		var me = new Person();
+		me.first = "John";
+		me.last = "Doe";
+
+		assert.ok(
+			canReflect.getKeyDependencies(me, "fullName").valueDependencies,
+			"should return the internal observation"
+		);
+	});
 
 	require("can-reflect-tests/observables/map-like/type/type")("class Type extends observe.Object", function() {
 		return class Type extends ObserveObject {};
@@ -139,10 +157,10 @@ QUnit.test("getters work", function(){
 		first: "Justin",
 		last: "Meyer"
 	});
-	
+
 	person.on("fullName", function fullNameCallback(ev, newName){
 		actions.push("fullNameCallback "+newName);
-	})
+	});
 	actions.push("on('fullName')");
 
 	QUnit.equal(person.fullName,"Justin Meyer", "full name is right");

--- a/object/object.js
+++ b/object/object.js
@@ -24,7 +24,7 @@ var ObserveObject = function(props) {
         prototype[computedDefinitionsSymbol] = getterHelpers.setupComputedProperties(prototype);
     }
 
-    // Define expando properties from `can.defienInstanceProperty`
+    // Define expando properties from `can.defineInstanceProperty`
     var sourceInstance = this;
     var definitions = prototype[definitionsSymbol] || {};
     for (var key in definitions) {

--- a/src/-add-get-key-dependencies.js
+++ b/src/-add-get-key-dependencies.js
@@ -1,0 +1,23 @@
+var canSymbol = require("can-symbol");
+
+var getKeyDependenciesSymbol = canSymbol.for("can.getKeyDependencies");
+var computedDefinitionsSymbol = canSymbol.for("can.computedDefinitions");
+
+module.exports = function addGetterKeyDependencies(obj) {
+	obj[getKeyDependenciesSymbol] = function getKeyDependencies(key) {
+		var computed = this[computedDefinitionsSymbol];
+
+		if (computed) {
+			var getObservation = computed[key];
+			var observationData = getObservation && getObservation(this);
+
+			if (observationData != null) {
+				return {
+					valueDependencies: new Set([ observationData.observation ])
+				};
+			}
+		}
+	};
+
+	return obj;
+};

--- a/src/-getter-helpers.js
+++ b/src/-getter-helpers.js
@@ -45,7 +45,7 @@ var getterHelpers = {
                     }
                 }
             }
-        });
+		});
 
         Type.prototype.addEventListener = function(key, handler, queue){
             var getObservation = this[computedDefinitionsSymbol][key];

--- a/src/-make-object.js
+++ b/src/-make-object.js
@@ -8,6 +8,7 @@ var mapBindings = require("can-event-queue/map/map");
 var symbols = require("./-symbols");
 var observableStore = require("./-observable-store");
 var helpers = require("./-helpers");
+var addGetterKeyDependencies = require("./-add-get-key-dependencies");
 
 var hasOwn = Object.prototype.hasOwnProperty;
 var isSymbolLike = canReflect.isSymbolLike;
@@ -18,6 +19,9 @@ var proxyKeys = Object.create(null);
 Object.getOwnPropertySymbols(mapBindings).forEach(function(symbol){
 	proxyKeys[symbol] = mapBindings[symbol];
 });
+
+// implement getKeyDependencies for computed getters
+addGetterKeyDependencies(proxyKeys);
 
 var makeObject = {
 


### PR DESCRIPTION
```js
class Person extends ObserveObject {
  get fullName() {
    return this.first + " " + this.last;
  }
}

var me = new Person();
me.first = "John";
me.last = "Doe";

draw(getGraph(me, "fullName"));
```

![screen shot 2017-12-29 at 10 21 50 am](https://user-images.githubusercontent.com/724877/34443603-7c67d3d8-ec85-11e7-97e0-3f74e5c29168.png)


