### PR TITLE
Ensure that all symbols have a corresponding descriptor

### DIFF
--- a/src/-helpers.js
+++ b/src/-helpers.js
@@ -78,7 +78,7 @@ var helpers = {
 
 			return Type;
 		};
-	}/*,
+	},
 	assignNonEnumerable: function(obj, key, value){
 		return Object.defineProperty(obj,key,{
 		    enumerable: false,
@@ -86,7 +86,7 @@ var helpers = {
 		    configurable: true,
 		    value: value
 		});
-	}*/
+	}
 };
 
 

--- a/test/object-test.js
+++ b/test/object-test.js
@@ -158,6 +158,15 @@ QUnit.skip("can.* symbols should not appear on object", function() {
 
 });
 
+QUnit.test("Symbols can be retrieved with getOwnPropertyDescriptor", function() {
+	var o = observe({});
+
+	Object.getOwnPropertySymbols(o).forEach(function(sym){
+		var desc = Object.getOwnPropertyDescriptor(o, sym);
+		QUnit.ok(!!desc, "There is a descriptor");
+	});
+});
+
 QUnit.test("don't wrap observable value, maps or lists", function(){
 	var simpleObservable = new SimpleObservable(1),
 		simpleMap = new SimpleMap();


### PR DESCRIPTION
Code might expect that the results of Object.getOwnPropertySymbols()
	will all have a descriptor, as is the case in normal objects.

This fixes #54