### PR TITLE
simple solution for lack of decorators

### DIFF
--- a/decorators/decorators-test-helpers.js
+++ b/decorators/decorators-test-helpers.js
@@ -26,6 +26,21 @@ function testDecoratorGetter(decoratorName, decorator, propName, getter, tester)
 			tester(TesterType);
 			QUnit.equal(ran, true, "getter ran");
 		});
+
+		QUnit.test(decoratorName + " getter decorator with class Object prototype (without decorator)", function() {
+			var ran = false;
+
+			class TesterType extends ObserveObject {
+				get [propName]() {
+					ran = true;
+					return getter.apply(this, arguments);
+				}
+			}
+			decorator(TesterType.prototype, propName);
+
+			tester(TesterType);
+			QUnit.equal(ran, true, "getter ran");
+		});
 	}
 
 	QUnit.test(decoratorName + " getter decorator with Object.extend prototype", function() {
@@ -38,6 +53,21 @@ function testDecoratorGetter(decoratorName, decorator, propName, getter, tester)
 			}
 		});
 		decorator(TesterType.prototype, propName, Object.getOwnPropertyDescriptor(TesterType.prototype, propName));
+
+		tester(TesterType);
+		QUnit.equal(ran, true, "getter ran");
+	});
+
+	QUnit.test(decoratorName + " getter decorator with Object.extend prototype (without decorator)", function() {
+		var ran = false;
+
+		var TesterType = ObserveObject.extend("TesterType", {}, {
+			get [propName]() {
+				ran = true;
+				return getter.apply(this, arguments);
+			}
+		});
+		decorator(TesterType.prototype, propName);
 
 		tester(TesterType);
 		QUnit.equal(ran, true, "getter ran");
@@ -60,6 +90,21 @@ function testDecoratorMethod(decoratorName, decorator, propName, method, tester)
 			tester(TesterType);
 			QUnit.equal(ran, true, "method ran");
 		});
+
+		QUnit.test(decoratorName + " method decorator with class Object prototype (without decorator)", function() {
+			var ran = false;
+
+			class TesterType extends ObserveObject {
+				[propName](resolve) {
+					ran = true;
+					return method.apply(this, arguments);
+				}
+			}
+			decorator(TesterType.prototype, propName);
+
+			tester(TesterType);
+			QUnit.equal(ran, true, "method ran");
+		});
 	}
 
 	QUnit.test(decoratorName + " method decorator with Object.extend prototype", function() {
@@ -72,6 +117,21 @@ function testDecoratorMethod(decoratorName, decorator, propName, method, tester)
 			},
 		});
 		decorator(TesterType.prototype, propName, Object.getOwnPropertyDescriptor(TesterType.prototype, propName));
+
+		tester(TesterType);
+		QUnit.equal(ran, true, "method ran");
+	});
+
+	QUnit.test(decoratorName + " method decorator with Object.extend prototype (without decorator)", function() {
+		var ran = false;
+
+		var TesterType = ObserveObject.extend("TesterType", {}, {
+			[propName](resolve) {
+				ran = true;
+				return method.apply(this, arguments);
+			},
+		});
+		decorator(TesterType.prototype, propName);
 
 		tester(TesterType);
 		QUnit.equal(ran, true, "method ran");

--- a/decorators/decorators-test-helpers.js
+++ b/decorators/decorators-test-helpers.js
@@ -27,7 +27,7 @@ function testDecoratorGetter(decoratorName, decorator, propName, getter, tester)
 			QUnit.equal(ran, true, "getter ran");
 		});
 
-		QUnit.test(decoratorName + " getter decorator with class Object prototype (without decorator)", function() {
+		QUnit.test(decoratorName + " getter decorator with class Object (without decorator)", function() {
 			var ran = false;
 
 			class TesterType extends ObserveObject {
@@ -36,7 +36,7 @@ function testDecoratorGetter(decoratorName, decorator, propName, getter, tester)
 					return getter.apply(this, arguments);
 				}
 			}
-			decorator(TesterType.prototype, propName);
+			decorator(TesterType, propName);
 
 			tester(TesterType);
 			QUnit.equal(ran, true, "getter ran");
@@ -58,7 +58,7 @@ function testDecoratorGetter(decoratorName, decorator, propName, getter, tester)
 		QUnit.equal(ran, true, "getter ran");
 	});
 
-	QUnit.test(decoratorName + " getter decorator with Object.extend prototype (without decorator)", function() {
+	QUnit.test(decoratorName + " getter decorator with Object.extend (without decorator)", function() {
 		var ran = false;
 
 		var TesterType = ObserveObject.extend("TesterType", {}, {
@@ -67,7 +67,7 @@ function testDecoratorGetter(decoratorName, decorator, propName, getter, tester)
 				return getter.apply(this, arguments);
 			}
 		});
-		decorator(TesterType.prototype, propName);
+		decorator(TesterType, propName);
 
 		tester(TesterType);
 		QUnit.equal(ran, true, "getter ran");
@@ -91,7 +91,7 @@ function testDecoratorMethod(decoratorName, decorator, propName, method, tester)
 			QUnit.equal(ran, true, "method ran");
 		});
 
-		QUnit.test(decoratorName + " method decorator with class Object prototype (without decorator)", function() {
+		QUnit.test(decoratorName + " method decorator with class Object (without decorator)", function() {
 			var ran = false;
 
 			class TesterType extends ObserveObject {
@@ -100,7 +100,7 @@ function testDecoratorMethod(decoratorName, decorator, propName, method, tester)
 					return method.apply(this, arguments);
 				}
 			}
-			decorator(TesterType.prototype, propName);
+			decorator(TesterType, propName);
 
 			tester(TesterType);
 			QUnit.equal(ran, true, "method ran");
@@ -122,7 +122,7 @@ function testDecoratorMethod(decoratorName, decorator, propName, method, tester)
 		QUnit.equal(ran, true, "method ran");
 	});
 
-	QUnit.test(decoratorName + " method decorator with Object.extend prototype (without decorator)", function() {
+	QUnit.test(decoratorName + " method decorator with Object.extend (without decorator)", function() {
 		var ran = false;
 
 		var TesterType = ObserveObject.extend("TesterType", {}, {
@@ -131,7 +131,7 @@ function testDecoratorMethod(decoratorName, decorator, propName, method, tester)
 				return method.apply(this, arguments);
 			},
 		});
-		decorator(TesterType.prototype, propName);
+		decorator(TesterType, propName);
 
 		tester(TesterType);
 		QUnit.equal(ran, true, "method ran");

--- a/decorators/decorators-test.js
+++ b/decorators/decorators-test.js
@@ -14,6 +14,7 @@ QUnit.module("can-observe/decorators");
 
 testDecorator("simple getter", function simpleDecorator(target, key, descriptor) {
 	if (!descriptor) {
+		target = target.prototype;
 		descriptor = Object.getOwnPropertyDescriptor(target, key);
 	}
 

--- a/decorators/decorators-test.js
+++ b/decorators/decorators-test.js
@@ -13,6 +13,10 @@ var decorators = require("./decorators");
 QUnit.module("can-observe/decorators");
 
 testDecorator("simple getter", function simpleDecorator(target, key, descriptor) {
+	if (!descriptor) {
+		descriptor = Object.getOwnPropertyDescriptor(target, key);
+	}
+
 	defineProperty(target, key, function(instance, property) {
 		return new Observation(descriptor.value || descriptor.get, instance);
 	});

--- a/decorators/decorators.js
+++ b/decorators/decorators.js
@@ -11,10 +11,6 @@ function defineProperty(prototype, prop, makeObservable) {
 
 function asyncBase(config) {
 	return function(target, key, descriptor) {
-		if (!descriptor) {
-			descriptor = Object.getOwnPropertyDescriptor(target, key);
-		}
-
 		if (descriptor.get !== undefined) {
 			var getter = descriptor.get;
 			//!steal-remove-start
@@ -86,10 +82,6 @@ function asyncBase(config) {
 
 function resolverBase(config) {
 	return function(target, key, descriptor) {
-		if (!descriptor) {
-			descriptor = Object.getOwnPropertyDescriptor(target, key);
-		}
-
 		if (descriptor.value !== undefined) {
 			var method = descriptor.value;
 			//!steal-remove-start
@@ -133,7 +125,27 @@ function optionalConfig(decorator) {
 	return wrapper;
 }
 
+function optionalPrototype(decorator) {
+	function wrapper(target, key, descriptor) {
+		if (arguments.length === 2) {
+			return decorator(target.prototype, key, Object.getOwnPropertyDescriptor(target.prototype, key));
+		}
+
+		return decorator(target, key, descriptor);
+	}
+
+	//!steal-remove-start
+	if(process.env.NODE_ENV !== 'production') {
+		Object.defineProperty(wrapper, "name", {
+			value: canReflect.getName(decorator.name)
+		});
+	}
+	//!steal-remove-end
+
+	return wrapper;
+}
+
 module.exports = {
-	async: optionalConfig(asyncBase),
-	resolver: optionalConfig(resolverBase),
+	async: optionalConfig(optionalPrototype(asyncBase)),
+	resolver: optionalConfig(optionalPrototype(resolverBase)),
 };

--- a/decorators/decorators.js
+++ b/decorators/decorators.js
@@ -11,6 +11,10 @@ function defineProperty(prototype, prop, makeObservable) {
 
 function asyncBase(config) {
 	return function(target, key, descriptor) {
+		if (!descriptor) {
+			descriptor = Object.getOwnPropertyDescriptor(target, key);
+		}
+
 		if (descriptor.get !== undefined) {
 			var getter = descriptor.get;
 			//!steal-remove-start
@@ -82,6 +86,10 @@ function asyncBase(config) {
 
 function resolverBase(config) {
 	return function(target, key, descriptor) {
+		if (!descriptor) {
+			descriptor = Object.getOwnPropertyDescriptor(target, key);
+		}
+
 		if (descriptor.value !== undefined) {
 			var method = descriptor.value;
 			//!steal-remove-start
@@ -107,11 +115,11 @@ function resolverBase(config) {
 
 function optionalConfig(decorator) {
 	function wrapper(config) {
-		if (arguments.length === 3) {
-			return decorator({}).apply(null, arguments);
+		if (arguments.length === 1) {
+			return decorator(config);
 		}
 
-		return decorator(config);
+		return decorator({}).apply(null, arguments);
 	}
 
 	//!steal-remove-start

--- a/decorators/decorators.js
+++ b/decorators/decorators.js
@@ -108,7 +108,7 @@ function resolverBase(config) {
 function optionalConfig(decorator) {
 	function wrapper(config) {
 		if (arguments.length === 1) {
-			return decorator(config);
+			return optionalConfig(decorator(config));
 		}
 
 		return decorator({}).apply(null, arguments);
@@ -126,12 +126,21 @@ function optionalConfig(decorator) {
 }
 
 function optionalPrototype(decorator) {
-	function wrapper(target, key, descriptor) {
-		if (arguments.length === 2) {
-			return decorator(target.prototype, key, Object.getOwnPropertyDescriptor(target.prototype, key));
+	function wrapper() {
+		if (arguments.length === 1) {
+			const config = arguments[0];
+			return optionalPrototype(decorator(config));
 		}
 
-		return decorator(target, key, descriptor);
+		if (arguments.length === 2) {
+			const target = arguments[0].prototype;
+			const key = arguments[1];
+			const descriptor = Object.getOwnPropertyDescriptor(target, key);
+
+			return decorator(target, key, descriptor);
+		}
+
+		return decorator.apply(null, arguments);
 	}
 
 	//!steal-remove-start


### PR DESCRIPTION
With this minor change file, we can allow one to call the function with the prototype and key, for environments where decorators are unavailable.

```javascript
export class Product extends ObserveObject {
	get details() {
		return Promise.resolve({});
	}
}

async(Product, 'details'); // <--
```